### PR TITLE
Add VectorLogoZone as a source

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Check out a running installation:
   * [Gilbarbara's SVG logos](https://github.com/gilbarbara/logos)
   * [Dan Leech's Simple Icons](https://github.com/danleech/simple-icons)
   * [Instant Logos](https://github.com/kogg/instant-logos)
+  * [VectorLogoZone](https://www.vectorlogo.zone/)
 
 ## Installation
 

--- a/bin/update-logos
+++ b/bin/update-logos
@@ -8,6 +8,7 @@ LOGOSPATH=${BASE_DIR}/logos
 GILBARBARA=${LOGOSPATH}/gilbarbara
 SIMPLEICONS=${LOGOSPATH}/simpleicons
 INSTANTLOGOS=${LOGOSPATH}/instantlogos
+VECTORLOGOZONE=${LOGOSPATH}/vectorlogozone
 
 if [ ! -d "$GILBARBARA" ]; then
   mkdir -p $GILBARBARA && \
@@ -28,4 +29,16 @@ if [ ! -d "$INSTANTLOGOS" ]; then
     git clone https://github.com/kogg/instant-logos.git $INSTANTLOGOS
 else
   cd $INSTANTLOGOS && git pull
+fi
+
+if [ ! -d "$VECTORLOGOZONE" ]; then
+  mkdir -p "$VECTORLOGOZONE"
+  cd "$VECTORLOGOZONE"
+  git init .
+  git remote add origin https://github.com/VectorLogoZone/vectorlogozone.git
+  git config core.sparsecheckout true
+  echo "www/logos/*/*.svg" >>.git/info/sparse-checkout
+  git pull --depth=1 origin gh-pages
+else
+  cd "$VECTORLOGOZONE" && git pull origin gh-pages
 fi

--- a/lib/sources/vectorlogozone.js
+++ b/lib/sources/vectorlogozone.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Retrieves VectorLogoZone's logos
+ * https://github.com/VectorLogoZone/vectorlogozone/
+ */
+
+module.exports = basePath => {
+  const absPath = path.join(basePath, 'vectorlogozone', 'www', 'logos');
+
+  const logos = [];
+  const logodirs = fs
+    .readdirSync(absPath)
+    .filter(file => fs.lstatSync(path.join(absPath, file)).isDirectory());
+  logodirs.forEach(logodir => {
+    const logofiles = fs
+      .readdirSync(path.join(absPath, logodir))
+      .filter(file => file.match(/\.svg$/));
+    logofiles.forEach(file => {
+      const name = file.replace(/-[^-]*\.svg$/, '');
+      const shortname = file
+        .replace(/\.svg$/, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '');
+
+      logos.push({
+        shortname,
+        name,
+        url: `https://www.vectorlogo.zone/logos/${logodir}/index.html`,
+        path: path.join('vectorlogozone', 'www', 'logos', logodir, file)
+      });
+    });
+  });
+
+  return Promise.resolve(logos);
+};


### PR DESCRIPTION
I don't have Sketch, so I couldn't do a complete end-to-end test, but the API results look right as far as I can tell.  Just to be sure I have the right values for the structure:
* name: text that will be searched (not necessarily unique)
* shortname: name stripped to alphanumeric (unique)

I had dependency problems with pino while running locally, but didn't want to change unrelated things.

You may want to bump MAX_RESULTS (or requery with startsWith instead of indexOf), since some common queries return too many results (for example "google")

I also noticed that shortname is not unique for instantlogos since it has files that differ only by case (for example: Zippo.svg and zippo.svg)

And the demo site URL in the README is down.